### PR TITLE
Remove the duplicate link to one of the Chinese external resources.

### DIFF
--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -728,7 +728,6 @@ Go 的上下文（context）也是 Go 并发编程的基石之一。上下文允
 
 * [最近読んだGo言語の本の紹介：100 Go Mistakes and How to Avoid Them](https://qiita.com/kentaro_suzuki/items/c9c31dc81217f237433c)
 * [『100 Go Mistakes and How to Avoid Them』を読む](https://zenn.dev/yukibobier/books/066f07c8a59fa0)
-* [100 Go Mistakes 随记 - 01 Code and project organization](https://zhuanlan.zhihu.com/p/592602656)
 
 ### 葡萄牙资料
 

--- a/docs/external.md
+++ b/docs/external.md
@@ -18,7 +18,6 @@
 
 * [最近読んだGo言語の本の紹介：100 Go Mistakes and How to Avoid Them](https://qiita.com/kentaro_suzuki/items/c9c31dc81217f237433c)
 * [『100 Go Mistakes and How to Avoid Them』を読む](https://zenn.dev/yukibobier/books/066f07c8a59fa0)
-* [100 Go Mistakes 随记 - 01 Code and project organization](https://zhuanlan.zhihu.com/p/592602656)
 
 ## Portuguese
 


### PR DESCRIPTION
When reading https://100go.co/external/ , I noticed this link ( https://juejin.cn/post/7241452578125824061 ) appears both in the Chinese and Japanese sections twice. This page is not Japanese (probably Chinese) so I went ahead and removed it from the Japanese section.

The same went with the Chinese version README as well.