### PR TITLE
Re-arranging some words , Mistake-45

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1028,7 +1028,7 @@ When using named result parameters, we must recall that each parameter is initia
 
 ???+ info "TL;DR"
 
-    When returning an interface, be cautious about returning not a nil pointer but an explicit nil value. Otherwise, unintended consequences may result because the caller will receive a non-nil value.
+    When returning an interface, be cautious about not returning a nil pointer but an explicit nil value. Otherwise, unintended consequences may occur and the caller will receive a non-nil value.
 
 <!-- TODO -->
 


### PR DESCRIPTION
Actual: 
When returning an interface, be cautious about returning not a nil pointer but an explicit nil value. Otherwise, unintended consequences may result because the caller will receive a non-nil value.


Changes
be cautious about returning not a nil pointer - > be cautious about not returning a nil pointer
may result because the  -> may occur and the caller
