### PR TITLE
Fix inconsistency in KB and MB in example code and output

### DIFF
--- a/docs/28-maps-memory-leaks.md
+++ b/docs/28-maps-memory-leaks.md
@@ -48,7 +48,7 @@ func main() {
 func printAlloc() {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
-	fmt.Printf("%d KB\n", m.Alloc/1024)
+	fmt.Printf("%d MB\n", m.Alloc/(1024*1024))
 }
 ```
 


### PR DESCRIPTION
Example output is given in `MB` but code snippet prints `KB`.

https://github.com/teivah/100-go-mistakes/blob/668d6165fe7cbb50c9ab839e87c86050c47a0c23/docs/28-maps-memory-leaks.md?plain=1#L57-L61