### PR TITLE
Fix sync.Pool example

### DIFF
--- a/src/12-optimizations/96-reduce-allocations/sync-pool/main.go
+++ b/src/12-optimizations/96-reduce-allocations/sync-pool/main.go
@@ -7,17 +7,21 @@ import (
 
 var pool = sync.Pool{
 	New: func() any {
-		return make([]byte, 1024)
+		b := make([]byte, 1024)
+		return &b
 	},
 }
 
 func write(w io.Writer) {
-	buffer := pool.Get().([]byte)
-	buffer = buffer[:0]
-	defer pool.Put(buffer)
+	bPtr := pool.Get().(*[]byte)
+	defer func() {
+		*bPtr = (*bPtr)[:0]
+		pool.Put(bPtr)
+	}()
 
-	getResponse(buffer)
-	_, _ = w.Write(buffer)
+	b := *bPtr
+	getResponse(b)
+	_, _ = w.Write(b)
 }
 
 func getResponse([]byte) {


### PR DESCRIPTION
The current implementation has a heap allocation (sic!).

There is also a bug as `buffer = buffer[:0]` should be executed just before putting the buffer back to the pool.

References:
- https://github.com/golang/example/blob/master/slog-handler-guide/README.md#speed 
- https://blog.mike.norgate.xyz/unlocking-go-slice-performance-navigating-sync-pool-for-enhanced-efficiency-7cb63b0b453e