### PR TITLE
Add comments to indicate it's a bad/good example

### DIFF
--- a/src/09-concurrency-practice/74-copying-sync/main.go
+++ b/src/09-concurrency-practice/74-copying-sync/main.go
@@ -19,7 +19,7 @@ func main() {
 }
 
 type Counter struct {
-	mu       sync.Mutex
+	mu       sync.Mutex // bad
 	counters map[string]int
 }
 
@@ -38,7 +38,7 @@ func (c *Counter) Increment2(name string) {
 }
 
 type Counter2 struct {
-	mu       *sync.Mutex
+	mu       *sync.Mutex // good
 	counters map[string]int
 }
 


### PR DESCRIPTION
The description for mistake [#74](https://100go.co/?h=sync#copying-a-sync-type-74) is already lacking. Understandably, the book has way more details. For those without the book, the referenced example might be confusing.

Minor updates to the referenced example to make it more explicit that it is a bad/good example.