### PR TITLE
Fix slice init length

### DIFF
--- a/src/09-concurrency-practice/69-data-race-append/main.go
+++ b/src/09-concurrency-practice/69-data-race-append/main.go
@@ -3,7 +3,7 @@ package main
 import "fmt"
 
 func listing1() {
-	s := make([]int, 1)
+	s := make([]int, 0, 1)
 
 	go func() {
 		s1 := append(s, 1)


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of 1, rather than initializing the length of this slice.

Now s is [0] rather than []