### PR TITLE
Remove unnecessary pointer dereference in 95-stack-heap/main_test.go

### DIFF
--- a/src/12-optimizations/95-stack-heap/main_test.go
+++ b/src/12-optimizations/95-stack-heap/main_test.go
@@ -22,5 +22,5 @@ func BenchmarkSumPtr(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		local = sumPtr(i, i)
 	}
-	globalValue = *local
+	globalPtr = local
 }


### PR DESCRIPTION
Fixed missed usage of globalPtr variable, which led to unnecessary dereferencing.