### PR TITLE
Go Mistake #100 - Add Warning with alternative solution.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2438,6 +2438,10 @@ When running some Go code inside Docker and Kubernetes, we must know that Go isn
 
 One solution is to rely on [uber-go/automaxprocs](https://github.com/uber-go/automaxprocs) that automatically set `GOMAXPROCS` to match the Linux container CPU quota.
 
+???+ warning
+
+   automaxprocs does not work for workloads running in AWS ECS [issue #66](https://github.com/uber-go/automaxprocs/issues/66). Use [rdforte/gomaxecs](https://github.com/rdforte/gomaxecs) instead. 
+
 ## Community
 
 Thanks to all the contributors:


### PR DESCRIPTION
## Description

The `automaxprocs` library from Uber does not set GOMAXPROCS for workloads running in AWS ECS.

Relevant issue: https://github.com/uber-go/automaxprocs/issues/66

## Proposal

Add a warning to go mistake [#100](https://100go.co/?h=kubernetes#not-understanding-the-impacts-of-running-go-in-docker-and-kubernetes-100), suggesting [gomaxecs](https://github.com/rdforte/gomaxecs/) as an alternative to address Go's CFS issue in ECS environment.