### PR TITLE
Fix - Text display outside warning window

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2440,7 +2440,7 @@ One solution is to rely on [uber-go/automaxprocs](https://github.com/uber-go/aut
 
 ???+ warning
 
-   automaxprocs does not work for workloads running in AWS ECS [issue #66](https://github.com/uber-go/automaxprocs/issues/66). Use [rdforte/gomaxecs](https://github.com/rdforte/gomaxecs) instead. 
+    automaxprocs does not work for workloads running in AWS ECS [issue #66](https://github.com/uber-go/automaxprocs/issues/66). Use [rdforte/gomaxecs](https://github.com/rdforte/gomaxecs) instead.
 
 ## Community
 


### PR DESCRIPTION
## Description
My previous PR https://github.com/teivah/100-go-mistakes/pull/110 included the addition of a warning. 
The text is being displayed outside the warning.
This fix moves the text into the warning.

### Current
![Screenshot 2025-02-04 at 9 15 43 am](https://github.com/user-attachments/assets/ce08d213-7e04-43a6-a4d1-b36b3f6fe535)

### With Change
![Screenshot 2025-02-04 at 9 15 30 am](https://github.com/user-attachments/assets/af61c1d6-6b8e-4db5-bb0f-f132de650a4d)


