### PR TITLE
fix: make the iteration time same

### DIFF
--- a/src/12-optimizations/91-cpu-caches/cache-line/main_test.go
+++ b/src/12-optimizations/91-cpu-caches/cache-line/main_test.go
@@ -19,7 +19,7 @@ func BenchmarkSum8(b *testing.B) {
 	var local int64
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		s := make([]int64, 1_000_000)
+		s := make([]int64, 4_000_000)
 		b.StartTimer()
 		local = sum8(s)
 	}


### PR DESCRIPTION
Set the length of sum8 to four times that of sum2 to ensure they perform the same number of iterations.
 #124 