### PR TITLE
Double the size of slice in BenchmarkSum2

### DIFF
--- a/src/12-optimizations/91-cpu-caches/predictability/main_test.go
+++ b/src/12-optimizations/91-cpu-caches/predictability/main_test.go
@@ -24,7 +24,7 @@ func BenchmarkSum2(b *testing.B) {
 	var local int64
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		s := make([]int64, n)
+		s := make([]int64, n*2)
 		b.StartTimer()
 		local = sum2(s)
 	}


### PR DESCRIPTION
It's unfair that `BenchmarkLinkedList` iterates n times while `BenchmarkSum2` iterates n/2 times because `i+=2` in `sum2`.